### PR TITLE
Allow suggestions when input is empty and use MRU order for suggestions

### DIFF
--- a/background.html
+++ b/background.html
@@ -1,6 +1,7 @@
 <script>
 var omnibox = chrome.omnibox;
 var topMatch;
+var mruTabIds = new Array();
 
 function escape(text) {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -31,6 +32,14 @@ function escapeRegexp(text) {
 }
 
 function parseMatches(text, search) {
+  if (search == '') {
+    return [
+      {
+        match: false,
+        text: escape(text)
+      }
+    ];
+  }
   var terms = escapeRegexp(search).split(/\s+/g);
   var termMatchCounts = [];
   terms.forEach(function() { termMatchCounts.push(0); });
@@ -83,40 +92,76 @@ function formatMatches(parsed) {
   }, "");
 }
 
+function formatDescription(matchItem) {
+  return formatMatches(matchItem.title) + ' - ' + '<url>'
+    + formatMatches(matchItem.url)+'</url>';
+}
+
+// initialize the mru tab ids to contain all of the tabs
+chrome.windows.getAll({populate: true}, function(windows) {
+  var tabs = windows.reduce(function(arr, win) {
+    return arr.concat(win.tabs);
+  }, []);
+  mruTabIds = tabs.reduce(function(ids, tab) {
+      return ids.concat(tab.id);
+  }, []);
+});
+
+chrome.tabs.onCreated.addListener(function(tab) {
+  mruTabIds.push(tab.id);
+});
+
+chrome.tabs.onSelectionChanged.addListener(function(tabId, selectInfo) {
+  if (mruTabIds.indexOf(tabId) != -1) {
+    mruTabIds.splice(mruTabIds.indexOf(tabId), 1);
+    mruTabIds.splice(0,0,tabId);
+  }
+});
+
+chrome.tabs.onRemoved.addListener(function(tabId) {
+  if(mruTabIds.indexOf(tabId) != -1)
+    mruTabIds.splice(mruTabIds.indexOf(tabId), 1);
+});
+
 omnibox.onInputChanged.addListener(function(text, suggest) {
   text = text.toLowerCase().replace(/\W+/g, ' ').trim();
-  if (!text)
-    return;
 
   chrome.windows.getAll({populate: true}, function(windows) {
     topMatch = -1;
-
     var tabs = windows.reduce(function(arr, win) {
       return arr.concat(win.tabs);
     }, []);
 
-    var suggestions = tabs.map(function(tab) {
-      return {
-        tab: tab,
-        title: parseMatches(tab.title, text),
-        url: parseMatches(tab.url, text)
-      };
+    var tabIds = tabs.reduce(function(ids, tab) {
+        return ids.concat(tab.id);
+    }, []);
+
+    var suggestions = mruTabIds.map(function(id) {
+      if (mruTabIds.indexOf(id) == 0) return null; // index 0 is the current tab, no need to handle it
+      var idx = tabIds.indexOf(id);
+      if (idx != -1 && tabs[idx]) {
+        return {
+          tab: tabs[idx],
+          title: parseMatches(tabs[idx].title, text),
+          url: parseMatches(tabs[idx].url, text)
+        };
+      }
+      return null;
     }).filter(function(item) {
-      if (item.title.length > 1 || item.url.length > 1) {
+      if (item && (text == '' || item.title.length > 1 || item.url.length > 1)) {
         if (topMatch == -1)
-          topMatch = item.tab.id;
+          topMatch = item;
         return true;
       } else {
         return false;
       }
     }).map(function(item) {
       return {
-        content: item.tab.title + ' - ' + item.tab.url + '#' + item.tab.id,
-        description: formatMatches(item.title) + ' - ' +
-                     '<url>' + formatMatches(item.url) + '</url>'
+        content: item.tab.url + ' #' + item.tab.id,
+        description: formatDescription(item)
       };
     });
-
+    updateDefaultSuggestion();
     suggest(suggestions);
   });
 });
@@ -126,16 +171,9 @@ omnibox.onInputEntered.addListener(function(url) {
   if (tabId)
     tabId = parseInt(tabId[1]);
   else if (topMatch != -1)
-    tabId = topMatch;
+    tabId = topMatch.tab.id;
   else
     return;
-
-  chrome.tabs.getSelected(null, function(selected) {
-    // if the selected tab was the new tab page,
-    // assume that it was blank, and close it!
-    if (selected.url == 'chrome://newtab/')
-      chrome.tabs.remove(selected.id);
-  });
 
   chrome.tabs.get(tabId, function(tab) {
     if (tab && !tab.selected) {
@@ -154,7 +192,18 @@ omnibox.onInputEntered.addListener(function(url) {
   });
 });
 
-omnibox.onInputCancelled.addListener(function() {
-  topMatch = -1;
-});
+//omnibox.onInputCancelled.addListener(function() {
+//  topMatch = -1;
+//});
+
+function updateDefaultSuggestion() {
+  var description = "No default tab to switch";
+  if (topMatch != -1) {
+    description='Switch to: ' + formatDescription(topMatch);
+  }
+  omnibox.setDefaultSuggestion({
+    description: description
+  });
+}
+
 </script>


### PR DESCRIPTION
Currently, it's a little inconvenient to get the tab list before you input any character as the search string; and it makes more sense to switch tabs between recently-used tabs. So I added the following functionality:
1) Give suggestions when the search input is empty, i.e. give suggestions right after users hit TAB to search;
2) The suggestions of the tabs are sorted in MRU order.
